### PR TITLE
Use non-web language in bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -22,7 +22,7 @@ A clear and concise description of what you expected to happen.
 If useful, add screenshots to help explain your problem.
 
 **Code example**
-If possible, share a minimal code reproduction the has the problem.
+If possible, share a minimal code reproduction of the problem.
 
 **Environment:**
  - OS: [e.g. Windows 10, iOS 14]


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes
In future we may have more precise requirements for debug information from
user, but this will be enough to make the template feel more cohesive with
Embark's domain.  :)

### Related Issues

https://github.com/EmbarkStudios/opensource/issues/4

### etc

I'm typing this from VS code and it deleted my changes twice. I think I might not use this feature again 😅 