### PR TITLE
Add support for non-embark maintainers

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -42,6 +42,7 @@
 
 mod error;
 mod github;
+mod policy;
 mod slack;
 mod validate;
 

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -1,0 +1,10 @@
+//! Policies for specific projects or users
+
+//! Generally we require that all maintainers of Embark Studios open source projects are
+//! part of the Embark org, but this list allows some explicit exceptions
+pub const ALLOWED_NON_EMBARK_MAINTAINERS: [&str; 1] = [
+    // Emil (https://github.com/emilk) worked at Embark and built 2 open source crates that he continues to co-maintain
+    // - https://github.com/EmbarkStudios/puffin
+    // - https://github.com/EmbarkStudios/poll-promise
+    "emilk",
+];

--- a/src/validate/project.rs
+++ b/src/validate/project.rs
@@ -3,7 +3,7 @@ use crate::github;
 use eyre::{eyre, WrapErr};
 use futures::TryFutureExt;
 use itertools::Itertools;
-use std::collections::HashSet;
+use std::{collections::HashSet, ops::Not};
 
 #[derive(Debug)]
 pub struct Project {
@@ -103,6 +103,13 @@ impl Project {
         // Ensure all maintainers are in the EmbarkStudios organisation
         let mut maintainers_not_in_embark = maintainers
             .difference(&context.embark_github_organisation_members)
+            .filter(|user_name| {
+                // filter out non-embark users that are explicitly allowed to be maintained
+                crate::policy::ALLOWED_NON_EMBARK_MAINTAINERS
+                    .iter()
+                    .any(|a| a == user_name)
+                    .not()
+            })
             .peekable();
         if maintainers_not_in_embark.peek().is_some() {
             return Err(eyre!(


### PR DESCRIPTION
We have a single such case with `emilk` that is an official co-maintainer of two of our projects.

This adds handling of that so our project checker doesn't complain about it every day on Slack.
