### PR TITLE
Add `keith` as non-embark maintainer

### DIFF
--- a/src/policy.rs
+++ b/src/policy.rs
@@ -6,7 +6,7 @@ pub const ALLOWED_NON_EMBARK_MAINTAINERS: [&str; 1] = [
     // Emil (https://github.com/emilk) worked at Embark and built 2 open source crates that he continues to co-maintain
     // - https://github.com/EmbarkStudios/puffin
     // - https://github.com/EmbarkStudios/poll-promise
-    "emilk",   
+    "emilk",
     // Keith (https://github.com/keith) is contributor-to and co-maintainer of the k8s-buildkite-plugin
     // https://github.com/EmbarkStudios/k8s-buildkite-plugin
     "keith",

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -2,7 +2,7 @@
 
 /// Generally we require that all maintainers of Embark Studios open source projects are
 /// part of the Embark org, but this list allows some explicit exceptions
-pub const ALLOWED_NON_EMBARK_MAINTAINERS: [&str; 1] = [
+pub const ALLOWED_NON_EMBARK_MAINTAINERS: [&str; 2] = [
     // Emil (https://github.com/emilk) worked at Embark and built 2 open source crates that he continues to co-maintain
     // - https://github.com/EmbarkStudios/puffin
     // - https://github.com/EmbarkStudios/poll-promise

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -7,6 +7,10 @@ pub const ALLOWED_NON_EMBARK_MAINTAINERS: [&str; 1] = [
     // - https://github.com/EmbarkStudios/puffin
     // - https://github.com/EmbarkStudios/poll-promise
     "emilk",
+    
+    // Keith (https://github.com/keith) is contributor-to and co-maintainer of the k8s-buildkite-plugin
+    // https://github.com/EmbarkStudios/k8s-buildkite-plugin
+    "keith",
 ];
 
 /// Some project might be public but not quite ready to be listed on the website

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -6,8 +6,7 @@ pub const ALLOWED_NON_EMBARK_MAINTAINERS: [&str; 1] = [
     // Emil (https://github.com/emilk) worked at Embark and built 2 open source crates that he continues to co-maintain
     // - https://github.com/EmbarkStudios/puffin
     // - https://github.com/EmbarkStudios/poll-promise
-    "emilk",
-    
+    "emilk",   
     // Keith (https://github.com/keith) is contributor-to and co-maintainer of the k8s-buildkite-plugin
     // https://github.com/EmbarkStudios/k8s-buildkite-plugin
     "keith",


### PR DESCRIPTION
### Description of Changes

Adds keith to the allowed non-embark maintainers.

### Related Issues

https://github.com/EmbarkStudios/k8s-buildkite-plugin/issues/50
