### PR TITLE
Fix maintenance-guidelines link

### DIFF
--- a/content/how-to.md
+++ b/content/how-to.md
@@ -15,7 +15,7 @@ You've got a new project - great! At Embark, we believe most things should be op
   - We don't want to release anything that could harm Embark from a security or intellectual property perspective. We also don't want to release something that doesn't work for non-Embarkers because it relies on an internal system. **You need to consult with your manager to assess any risks associated with releasing your project.**
 
 - **Can you commit to maintaining the project for the foreseeable future?**
-  - See the [maintenance guidelines](maintenance-guidelines) to see what is required from an Embark open source maintainer.
+  - See the [maintenance guidelines](maintenance-guidelines.md) to see what is required from an Embark open source maintainer.
   - If no, you can still release ["as-is"](#repository-types) in an archived GitHub repository.
 
 - **Is it high enough quality?**


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](https://github.com/EmbarkStudios/opensource/blob/main/CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](https://github.com/EmbarkStudios/opensource/blob/main/CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

The relative link for maintenance guidelines returns 404 on GitHub
